### PR TITLE
Fix #30 - docker image conflict on restart

### DIFF
--- a/inst/cloudconfig/rstudio.yaml
+++ b/inst/cloudconfig/rstudio.yaml
@@ -26,6 +26,7 @@ write_files:
                                   --name=rstudio \
                                   %s
     ExecStop=/usr/bin/docker stop rstudio
+    ExecStopPost=/usr/bin/docker rm rstudio
 
 runcmd:
 - systemctl daemon-reload


### PR DESCRIPTION
This removes the container when the service is stopped, and fixes a naming conflict in the restart of the service. See details in issue #30.