### PR TITLE
Authorize digits in project name

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -4,7 +4,7 @@ is.lower_hypen <- function(x){
     assertthat::is.string(x)
   )
   
-  grepl("^[a-z\\-]+$", x)
+  grepl("^[a-z\\d\\-]+$", x)
   
 }
 assertthat::on_failure(is.lower_hypen) <- function(call, env){


### PR DESCRIPTION
I'm not sure why underscores aren't supported, but as I stumbled upon this issue I stick with the initial description made in bug #72 

