### PR TITLE
previously created externalIP can now be entered

### DIFF
--- a/R/networks.R
+++ b/R/networks.R
@@ -38,22 +38,10 @@ gce_make_network <- function(name,
                              externalIP = NULL,
                              project = gce_get_global_project()){
   
-  net <- gce_get_network(network, project = project)
-  
-  if(!is.null(externalIP)){
-    if(externalIP == "none"){
-      ac <- NULL
-    } else { #ENTERED IP/VALID IF ALREADY CREATED 
-      ac <- list(
-        list(
-          natIP = jsonlite::unbox(externalIP),
-          type = jsonlite::unbox("ONE_TO_ONE_NAT"),
-          name = jsonlite::unbox(name)
-        )
-      )
-    }
-  } else { #NULL
-    ac <- list(
+  make_ac <- function(externalIP, name){
+    if(!is.null(externalIP) && externalIP == "none") return(NULL)
+    
+    list(
       list(
         natIP = jsonlite::unbox(externalIP),
         type = jsonlite::unbox("ONE_TO_ONE_NAT"),
@@ -62,11 +50,13 @@ gce_make_network <- function(name,
     )
   }
   
+  net <- gce_get_network(network, project = project)
+  
   structure(
     list(
       list(
         network = jsonlite::unbox(net$selfLink),
-        accessConfigs = ac
+        accessConfigs = make_ac(externalIP, name)
       )
     ),
     class = c("gce_networkInterface", "list")

--- a/R/networks.R
+++ b/R/networks.R
@@ -43,13 +43,21 @@ gce_make_network <- function(name,
   if(!is.null(externalIP)){
     if(externalIP == "none"){
       ac <- NULL
+    } else { #ENTERED IP/VALID IF ALREADY CREATED 
+      ac <- list(
+        list(
+          natIP = jsonlite::unbox(externalIP),
+          type = jsonlite::unbox("ONE_TO_ONE_NAT"),
+          name = jsonlite::unbox(name)
+        )
+      )
     }
-  } else {
+  } else { #NULL
     ac <- list(
       list(
-      natIP = jsonlite::unbox(externalIP),
-      type = jsonlite::unbox("ONE_TO_ONE_NAT"),
-      name = jsonlite::unbox(name)
+        natIP = jsonlite::unbox(externalIP),
+        type = jsonlite::unbox("ONE_TO_ONE_NAT"),
+        name = jsonlite::unbox(name)
       )
     )
   }

--- a/tests/test_externalIP.R
+++ b/tests/test_externalIP.R
@@ -3,11 +3,12 @@ options(googleAuthR.scopes.selected = "https://www.googleapis.com/auth/cloud-pla
 devtools::load_all()
 
 vm <- gce_vm(template = "rstudio",
-             name = "rstudio-server-8",
+             name = "rstudio-server-10",
              username = "jas", password = "jas12345",
              predefined_type = "n1-standard-8",
+             #externalIP = "35.230.96.64" 
              #externalIP = "103.323.2323.232" #invalid ip
-             #externalIP = "35.230.96.64" #https://github.com/cloudyr/googleComputeEngineR/issues/69
              externalIP = "none"
+             #externalIP = NULL
 )
 

--- a/tests/test_externalIP.R
+++ b/tests/test_externalIP.R
@@ -1,0 +1,13 @@
+options(googleAuthR.scopes.selected = "https://www.googleapis.com/auth/cloud-platform")
+
+devtools::load_all()
+
+vm <- gce_vm(template = "rstudio",
+             name = "rstudio-server-8",
+             username = "jas", password = "jas12345",
+             predefined_type = "n1-standard-8",
+             #externalIP = "103.323.2323.232" #invalid ip
+             #externalIP = "35.230.96.64" #https://github.com/cloudyr/googleComputeEngineR/issues/69
+             externalIP = "none"
+)
+

--- a/tests/testthat/test_externalIP.R
+++ b/tests/testthat/test_externalIP.R
@@ -1,0 +1,44 @@
+library(googleComputeEngineR)
+
+context("externalIP")
+
+test_that("A new External IP is automatically created and assigned to the VM", {
+  vm <- gce_vm(template = "rstudio",
+               name = "rstudio-server-6",
+               username = "jas", password = "jas12345",
+               predefined_type = "n1-standard-8",
+               externalIP = NULL
+  )
+  expect_equal(vm$status, "RUNNING")
+})
+
+test_that("We can assign an External IP already created to the VM", {
+  vm <- gce_vm(template = "rstudio",
+               name = "rstudio-server-6",
+               username = "jas", password = "jas12345",
+               predefined_type = "n1-standard-8",
+               externalIP = "35.230.96.64" 
+  )
+  expect_equal(vm$status, "RUNNING")
+})
+
+test_that("An invalid IP which has not been previous created shouldn't work.", {
+  vm <- gce_vm(template = "rstudio",
+               name = "rstudio-server-6",
+               username = "jas", password = "jas12345",
+               predefined_type = "n1-standard-8",
+               externalIP = "103.323.2323.232" 
+  )
+ #An error message should appear similar to:
+ #Error: API returned: Invalid value for field 'resource.networkInterfaces[0].accessConfigs[0].natIP': '103.323.2323.232'. The specified external IP address '103.323.2323.232' was not found in region 'us-west1'. 
+})
+
+test_that("No IP should be assigned to the VM if externalIP specified as none", {
+  vm <- gce_vm(template = "rstudio",
+               name = "rstudio-server-7",
+               username = "jas", password = "jas12345",
+               predefined_type = "n1-standard-8",
+               externalIP = "none" 
+  )
+  expect_equal(gce_get_external_ip(vm), NULL)
+})


### PR DESCRIPTION
I tested this out both using my basic test file and I attempted to use testthat as well. I tried to find a way to remove what appears to be redundant code, but I couldn't find any way since R gives a failure message if you try to compare a NULL value with a comparison operator ```if(externalIP == "none")```  when externalIP is NULL won't work. In actuality, there are only two real possibilities here, either it is "none" then you assign NULL to ac, otherwise externalIP is NULL or an entered IP (can be valid or invalid) and then you create that ac variable. 