### PR TITLE
Replace 'cat' with 'message' in .Rprofile

### DIFF
--- a/inst/dockerfiles/persistentRStudio/Rprofile.site
+++ b/inst/dockerfiles/persistentRStudio/Rprofile.site
@@ -1,5 +1,5 @@
 .First <- function(){
-  cat("\n# Welcome to RStudio Server on Google Compute Engine! Today is ", date(), "\n")
+  message("\n# Welcome to RStudio Server on Google Compute Engine! Today is ", date(), "\n")
   
   googleCloudStorageR::gcs_first()
 }


### PR DESCRIPTION
I'm trying to install a package (minqa) which contains in its Makevars:

```
PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"`
```

When I install this, the welcome message gets added to the linker command as follows:
```
g++ -shared -L/usr/local/lib/R/lib -L/usr/local/lib -o minqa.so altmov.o bigden.o biglag.o bobyqa.o bobyqb.o lagmax.o minqa.o newuoa.o newuob.o prelim.o rescue.o trsapp.o trsbox.o trstep.o uobyqa.o uobyqb.o update.o updatebobyqa.o # Welcome to RStudio Server on Google Compute Engine! Today is Wed Mar 14 18:49:17 2018 -lgfortran -lm -lquadmath -L/usr/local/lib/R/lib -lR
```

Wrapping the welcome message in `message()` rather than `cat()` fixes this problem.