### PR TITLE
Pass zone and project arguments through to vm-related functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: googleComputeEngineR
 Type: Package
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Title: R Interface with Google Compute Engine
 Description: Interact with the 'Google Compute Engine' API in R. Lets you create, 
   start and stop instances in the 'Google Cloud'.  Support for preconfigured instances, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.2.0.9001
+
+- Fixed broken passing of `zone` and `project` arguments in `gce_vm`, `gce_vm_template`, `gce_get_external_ip`, and `gce_set_metadata`.
+
 # 0.2.0.9000
 
 * remove `gce_auth()` to favour auth with JSON key (#79)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -120,7 +120,7 @@ gce_set_metadata <- function(metadata,
                              zone = gce_get_global_zone()) {
 
   ## refetch to ensure latest version of metadata fingerprint
-  ins <- gce_get_instance(instance)
+  ins <- gce_get_instance(instance, project = project, zone = zone)
   
   url <- sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s/setMetadata", 
                  project, zone, as.gce_instance_name(ins))

--- a/R/networks.R
+++ b/R/networks.R
@@ -11,7 +11,7 @@ gce_get_external_ip <- function(instance,
                                 verbose = TRUE,
                                 ...){
 
-  ins <- as.gce_instance(instance)
+  ins <- as.gce_instance(instance, ...)
 
   ip <- ins$networkInterfaces$accessConfigs[[1]]$natIP
   

--- a/R/template.R
+++ b/R/template.R
@@ -134,6 +134,12 @@ gce_vm_template <- function(template = c("rstudio","shiny","opencpu",
     message("No VM name specified, defaulting to ", template)
     dots$name <- template
   }
+  if(is.null(dots$zone)){
+    dots$zone <- gce_get_global_zone()
+  }
+  if(is.null(dots$project)){
+    dots$project <- gce_get_global_project()
+  }
   
   template <- match.arg(template)
   
@@ -167,8 +173,8 @@ gce_vm_template <- function(template = c("rstudio","shiny","opencpu",
     return(job)
   }
 
-  ins <- gce_get_instance(dots$name)
-  ip <- gce_get_external_ip(dots$name)
+  ins <- gce_get_instance(dots$name, project = dots$project, zone = dots$zone)
+  ip <- gce_get_external_ip(dots$name, project = dots$project, zone = dots$zone)
   
   ## where to find application
   ip_suffix <- ""

--- a/R/vms.R
+++ b/R/vms.R
@@ -87,28 +87,28 @@ gce_vm <- function(name,
   }
   
   vm <- tryCatch({
-    suppressMessages(suppressWarnings(gce_get_instance(name)))
+    suppressMessages(suppressWarnings(gce_get_instance(name, zone = zone, project = project)))
   }, error = function(ex) {
     dots <- list(...)
     if(!is.null(dots[["template"]])){
       
       myMessage("Creating template VM", level = 3)
-      do.call(gce_vm_template, c(list(...), name = name))
+      do.call(gce_vm_template, c(list(...), name = name, zone = zone, project = project))
       ## gce_vm_template has its own gce_wait()
       
     } else if(any(!is.null(dots[["file"]]), !is.null(dots[["cloud_init"]]))){
       
       myMessage("Creating container VM", level = 3)
-      job <- do.call(gce_vm_container, c(list(...), name = name))
+      job <- do.call(gce_vm_container, c(list(...), name = name, zone = zone, project = project))
       gce_wait(job)
-      gce_get_instance(name)
+      gce_get_instance(name, zone = zone, project = project)
       
     } else {
       
       myMessage("Creating standard VM", level = 3)
-      job <- do.call(gce_vm_create, c(list(...), name = name))
+      job <- do.call(gce_vm_create, c(list(...), name = name, zone = zone, project = project))
       gce_wait(job)
-      gce_get_instance(name)
+      gce_get_instance(name, zone = zone, project = project)
       
     }
   })


### PR DESCRIPTION
Zones and projects other than the default were not being passed through to vm creation/modification/access functions. This pr fixes this in the following functions:

- `gce_set_metadata` (passed to `gce_get_instance`)
- `gce_get_external_ip` (passed to `as.gce_instance`)
- `gce_vm_template` (passed to `gce_vm_container`, `gce_get_instance` and `gce_get_external_ip`)
- `gce_vm` (passed to `gce_get_instance`, `gce_vm_template`, `gce_vm_container`, and `gce_vm_create`)