### PR TITLE
Account for `dynamic_image` being `NULL`

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -106,7 +106,7 @@ gce_vm_template <- function(template = c("rstudio",
     image_project   <-  "cos-cloud"
   }
 
-  if (grepl("^http(s|)://gcr.io/", dynamic_image)) {
+  if (!is.null(dynamic_image) && grepl("^http(s|)://gcr.io/", dynamic_image)) {
     dynamic_image = sub("http(s|)://", "", dynamic_image)
   }
   # adds metadata startup script will read


### PR DESCRIPTION
Fixes #181 

I have no idea if this is the desired solution, but it did allow me to continue to _not_ specify `dynamic_image`, which made me happy because whatever is happening by default seems fine for my purposes.