### PR TITLE
added privileged for nauth

### DIFF
--- a/inst/startupscripts/rstudio-noauth.sh
+++ b/inst/startupscripts/rstudio-noauth.sh
@@ -16,4 +16,5 @@ docker run -p 8787:8787 \
            -e ROOT=TRUE \
            -e USER=rstudio -e DISABLE_AUTH=true \
            --name=rstudio \
+           --privileged=true \
            $GCER_DOCKER_IMAGE


### PR DESCRIPTION
Allows docker to run privileged so it can use cron and other dbus things easily.